### PR TITLE
Polish up error checking

### DIFF
--- a/core/record/record.go
+++ b/core/record/record.go
@@ -163,9 +163,8 @@ func (rec *Record) Deserialize(reader *bufio.Reader) (eof bool) {
 	crc := crc32.ChecksumIEEE(append(rec.Key[:], rec.Value[:]...))
 
 	if crc != rec.Crc {
-		fmt.Println("Bad Record checksum (got ", crc, ", expected ", rec.Crc, ")")
-		fmt.Println(rec.String())
-		panic("")
+		errMsg := fmt.Sprint("Bad Record checksum (got ", crc, ", expected ", rec.Crc, ")\n", rec.String())
+		panic(errMsg)
 	}
 
 	return false

--- a/core/skiplist/skiplist.go
+++ b/core/skiplist/skiplist.go
@@ -19,13 +19,13 @@ type Skiplist struct {
 // Throws an error if specified height is greater than the maximium allowed height or less than 1.
 func New(level int, levelmax int) Skiplist {
 	if level > levelmax {
-		fmt.Println("Maximum skiplist height is", levelmax, ", but", level, "was given.")
-		panic(nil)
+		errMsg := fmt.Sprint("Maximum skiplist height is", levelmax, ", but", level, "was given.")
+		panic(errMsg)
 	}
 
 	if level <= 0 {
-		fmt.Println("Minimum skiplist height is 1, but", level, "was given.")
-		panic(nil)
+		errMsg := fmt.Sprint("Minimum skiplist height is 1, but", level, "was given.")
+		panic(errMsg)
 	}
 
 	header := newNodeEmpty(levelmax)

--- a/core/wal/wal.go
+++ b/core/wal/wal.go
@@ -159,7 +159,7 @@ func (wal *WAL) addSegment() {
 	wal.lastSegmentNumOfRecords = 0
 }
 
-// Helper function used by BufferReader to partially flush its contents to the
+// Helper function used by FlushBuffer to partially flush its contents to the
 // segment.
 func (wal *WAL) flushPartialBufferToSegment(partialBuffer []record.Record) {
 	file, err := os.OpenFile(wal.lastSegmentPath, os.O_RDWR, 0666)


### PR DESCRIPTION
In several places, we would panic with nil or an empty string, while also seperately printing the error to stdout. This patch makes it so that the error messages get passed to panic instead.

Also includes a WAL comment fix.