### PR TITLE
Everything: Change how we react to errors

### DIFF
--- a/core/lru/lru.go
+++ b/core/lru/lru.go
@@ -6,7 +6,6 @@ import (
 	"nakevaleng/core/record"
 )
 
-// TODO: Make Capacity configurable
 type LRU struct {
 	Capacity int
 	Order    list.List
@@ -17,17 +16,25 @@ type LRU struct {
 //  capacity    Maximum size of the LRU
 //  returns     Pointer to an LRU object
 // Throws if the passed capacity is not a positive number.
-func New(capacity int) *LRU {
-	if capacity <= 0 {
-		errMsg := fmt.Sprint("capacity must be a positive number, but ", capacity, " was given.")
-		panic(errMsg)
+func New(capacity int) (*LRU, error) {
+	err := ValidateParams(capacity)
+	if err != nil {
+		return nil, err
 	}
 
 	return &LRU{
 		Capacity: capacity,
 		Order:    list.List{},
 		Data:     map[string]*list.Element{},
+	}, nil
+}
+
+func ValidateParams(capacity int) error {
+	if capacity <= 0 {
+		err := fmt.Errorf("capacity must be a positive number, but %d was given", capacity)
+		return err
 	}
+	return nil
 }
 
 // Get retrieves the record stored in the LRU based on the passed key.

--- a/core/lsmtree/lsmtree.go
+++ b/core/lsmtree/lsmtree.go
@@ -32,7 +32,39 @@ func needsCompaction(path, dbname string, level int, RUN_MAX int) bool {
 // The result of a compaction is a new SSTable in the first available run on the next level.
 // Chaining is performed in case the next level requires a compation after a new SSTable is created.
 // Only the Data table is created from the existing set, everything else is recreated.
-func Compact(path, dbname string, summaryPageSize int, level int, LVL_MAX, RUN_MAX int) {
+func Compact(path, dbname string, summaryPageSize int, level int, LVL_MAX, RUN_MAX int) error {
+	err := ValidateParams(summaryPageSize, level, LVL_MAX, RUN_MAX)
+	if err != nil {
+		return err
+	}
+
+	compact(path, dbname, summaryPageSize, level, LVL_MAX, RUN_MAX)
+
+	return nil
+}
+
+func ValidateParams(summaryPageSize int, level int, LVL_MAX, RUN_MAX int) error {
+	if summaryPageSize < 0 {
+		err := fmt.Errorf("summaryPageSize must be greater than or equal to zero, but %d was given", summaryPageSize)
+		return err
+	}
+	if level < 0 {
+		err := fmt.Errorf("level must be greater than or equal to zero, but %d was given", level)
+		return err
+	}
+	if LVL_MAX < 0 {
+		err := fmt.Errorf("LVL_MAX must be greater than or equal to zero, but %d was given", LVL_MAX)
+		return err
+	}
+	if RUN_MAX < 0 {
+		err := fmt.Errorf("RUN_MAX must be greater than or equal to zero, but %d was given", RUN_MAX)
+		return err
+	}
+
+	return nil
+}
+
+func compact(path, dbname string, summaryPageSize int, level int, LVL_MAX, RUN_MAX int) {
 	if !needsCompaction(path, dbname, level, RUN_MAX) {
 		return
 	}
@@ -88,7 +120,7 @@ func Compact(path, dbname string, summaryPageSize int, level int, LVL_MAX, RUN_M
 
 	// Chaining (won't do anything if next level doesn't need compaction yet).
 
-	Compact(path, dbname, summaryPageSize, level+1, LVL_MAX, RUN_MAX)
+	compact(path, dbname, summaryPageSize, level+1, LVL_MAX, RUN_MAX)
 }
 
 // merge performs a k-way merge for the tables on a given level.

--- a/core/memtable/memtable.go
+++ b/core/memtable/memtable.go
@@ -11,22 +11,23 @@ import (
 )
 
 type Memtable struct {
-	conf      coreconf.CoreConfig
+	conf      *coreconf.CoreConfig
 	memusage  uint64
 	threshold uint64
 	sl        *skiplist.Skiplist
 }
 
 // Returns a pointer to a new Memtable object.
-func New(conf coreconf.CoreConfig) *Memtable {
-	sl := skiplist.New(conf.SkiplistLevel, conf.SkiplistLevelMax)
+func New(conf *coreconf.CoreConfig) (*Memtable, error) {
+	// if conf is valid, this should never fail
+	sl, _ := skiplist.New(conf.SkiplistLevel, conf.SkiplistLevelMax)
 
 	return &Memtable{
 		conf:      conf,
 		memusage:  uint64(0),
 		threshold: conf.MemtableThresholdBytes(),
 		sl:        sl,
-	}
+	}, nil
 }
 
 // Add a record to the memtable.

--- a/core/skiplist/skiplist.go
+++ b/core/skiplist/skiplist.go
@@ -17,15 +17,10 @@ type Skiplist struct {
 // New creates an empty Skiplist with height 'level'.
 // 	level	Number of available levels in range [0, level).
 // Throws an error if specified height is greater than the maximium allowed height or less than 1.
-func New(level int, levelmax int) *Skiplist {
-	if level > levelmax {
-		errMsg := fmt.Sprint("Maximum skiplist height is", levelmax, ", but", level, "was given.")
-		panic(errMsg)
-	}
-
-	if level <= 0 {
-		errMsg := fmt.Sprint("Minimum skiplist height is 1, but", level, "was given.")
-		panic(errMsg)
+func New(level int, levelmax int) (*Skiplist, error) {
+	err := ValidateParams(level, levelmax)
+	if err != nil {
+		return nil, err
 	}
 
 	header := newNodeEmpty(levelmax)
@@ -35,7 +30,20 @@ func New(level int, levelmax int) *Skiplist {
 		LevelMax: levelmax,
 		Header:   &header,
 		Count:    0,
+	}, nil
+}
+
+func ValidateParams(level, levelmax int) error {
+	if level > levelmax {
+		err := fmt.Errorf("maximum skiplist height is %d, but %d was given", levelmax, level)
+		return err
 	}
+	if level <= 0 {
+		err := fmt.Errorf("minimum skiplist height is 1, but %d was given", level)
+		return err
+	}
+
+	return nil
 }
 
 // Clear removes all nodes from the Skiplist and resets the number of levels to 1.

--- a/core/sstable/sstable.go
+++ b/core/sstable/sstable.go
@@ -35,12 +35,19 @@ func MakeTable(path, dbname string, summaryPageSize, level, run int, list *skipl
 func MakeTableSecondaries(path, dbname string, summaryPageSize, level, run int, merkleleaves []merkletree.MerkleNode, keyctx []record.KeyContext) {
 	makeIndexAndSummary(path, dbname, summaryPageSize, level, run, keyctx)
 	makeFilter(path, dbname, level, run, keyctx)
-	merkleTree := merkletree.New(merkleleaves)
+
+	// MakeTableSecondaries and makeMetadata are the only places where merkletree New is called, so I guess panic here?
+	// In any case, old behaviour was to panic as well (but in merkletree build)
+	merkleTree, err := merkletree.New(merkleleaves)
+	if err != nil {
+		panic(err)
+	}
+
 	merkleTree.Serialize(filename.Table(path, dbname, level, run, filename.TypeMetadata))
 }
 
 func makeFilter(path, dbname string, level, run int, keyctx []record.KeyContext) {
-	bf := bloomfilter.New(len(keyctx), 0.01)
+	bf, _ := bloomfilter.New(len(keyctx), 0.01)
 	for _, kc := range keyctx {
 		bf.Insert(kc.Key)
 	}
@@ -58,7 +65,13 @@ func makeMetadata(path, dbname string, level, run int, list *skiplist.Skiplist) 
 		}
 	}
 
-	merkleTree := merkletree.New(merkleNodes)
+	// MakeTableSecondaries and makeMetadata are the only places where merkletree New is called, so I guess panic here?
+	// In any case, old behaviour was to panic as well (but in merkletree build)
+	merkleTree, err := merkletree.New(merkleNodes)
+	if err != nil {
+		panic(err)
+	}
+
 	merkleTree.Serialize(filename.Table(path, dbname, level, run, filename.TypeMetadata))
 }
 

--- a/core/wal/wal.go
+++ b/core/wal/wal.go
@@ -27,18 +27,10 @@ type WAL struct {
 
 // Returns a pointer to a WAL object.
 // If no segments are present in the directory, it will create one.
-func New(walPath, dbname string, maxRecordsInSegment, lowWaterMarkIndex, appendingBufferCapacity int) *WAL {
-	if maxRecordsInSegment <= 0 {
-		errMsg := fmt.Sprint("maxRecordsInSegment must be a positive number, but ", maxRecordsInSegment, " was given.")
-		panic(errMsg)
-	}
-	if lowWaterMarkIndex < 0 {
-		errMsg := fmt.Sprint("lowWaterMarkIndex must be greater than or equal to zero, but ", lowWaterMarkIndex, " was given.")
-		panic(errMsg)
-	}
-	if appendingBufferCapacity <= 0 {
-		errMsg := fmt.Sprint("appendingBufferCapacity must be a positive number, but ", appendingBufferCapacity, " was given.")
-		panic(errMsg)
+func New(walPath, dbname string, maxRecordsInSegment, lowWaterMarkIndex, appendingBufferCapacity int) (*WAL, error) {
+	err := ValidateParams(maxRecordsInSegment, lowWaterMarkIndex, appendingBufferCapacity)
+	if err != nil {
+		return nil, err
 	}
 
 	segmentPaths := filename.GetSegmentPaths(walPath, dbname)
@@ -68,7 +60,25 @@ func New(walPath, dbname string, maxRecordsInSegment, lowWaterMarkIndex, appendi
 		maxRecordsInSegment:     maxRecordsInSegment,
 		lowWaterMarkIndex:       lowWaterMarkIndex,
 		appendingBufferCapacity: appendingBufferCapacity,
-		appendingBuffer:         appendingBuffer}
+		appendingBuffer:         appendingBuffer,
+	}, nil
+}
+
+func ValidateParams(maxRecordsInSegment, lowWaterMarkIndex, appendingBufferCapacity int) error {
+	if maxRecordsInSegment <= 0 {
+		err := fmt.Errorf("maxRecordsInSegment must be a positive number, but %d was given", maxRecordsInSegment)
+		return err
+	}
+	if lowWaterMarkIndex < 0 {
+		err := fmt.Errorf("lowWaterMarkIndex must be greater than or equal to zero, but %d was given", lowWaterMarkIndex)
+		return err
+	}
+	if appendingBufferCapacity <= 0 {
+		err := fmt.Errorf("appendingBufferCapacity must be a positive number, but %d was given", appendingBufferCapacity)
+		return err
+	}
+
+	return nil
 }
 
 // Helper function that returns the current number of records present in the segment.

--- a/ds/bloomfilter/bloomfilter.go
+++ b/ds/bloomfilter/bloomfilter.go
@@ -47,7 +47,16 @@ type BloomFilter struct {
 // New Creates a new BloomFilter object.
 // expectedElements is the number of elements likely to be inserted.
 // falsePositiveRate is the probability of error when querying from 0 to 1; if unsure use 0.1.
-func New(expectedElements int, falsePositiveRate float64) *BloomFilter {
+func New(expectedElements int, falsePositiveRate float64) (*BloomFilter, error) {
+	if expectedElements < 0 {
+		err := fmt.Errorf("expectedElements must be greater than or equal to zero, but %d was given", expectedElements)
+		return nil, err
+	}
+	if falsePositiveRate < 0.0 || falsePositiveRate > 1.0 {
+		err := fmt.Errorf("falsePositiveRate must be between (0, 1), but %f was given", falsePositiveRate)
+		return nil, err
+	}
+
 	m := calculateM(expectedElements, falsePositiveRate)
 	k := calculateK(expectedElements, m)
 	hashes, seeds := createHashFunctions(k)
@@ -58,7 +67,7 @@ func New(expectedElements int, falsePositiveRate float64) *BloomFilter {
 		HashSeeds: seeds,
 		Contents:  make([]byte, int(math.Ceil(float64(m)/8))),
 		hashes:    hashes,
-	}
+	}, nil
 }
 
 // Insert inserts a byte sequence into the bloom filter.
@@ -172,7 +181,7 @@ func (bf *BloomFilter) EncodeToBytes() []byte {
 
 func main() {
 	// change package name to main for a quick test
-	bf := New(100, 0.2)
+	bf, _ := New(100, 0.2)
 	fmt.Println(bf)
 	bf.Insert([]byte{1, 2})
 	bf.Insert([]byte{3, 4})

--- a/ds/cmsketch/cmsketch.go
+++ b/ds/cmsketch/cmsketch.go
@@ -47,7 +47,16 @@ type CountMinSketch struct {
 // New creates a new CountMinSketch object.
 // epsilon is the rate of imprecision (0, 1), if unsure use 0.1.
 // delta is the rate of error (0, 1), if unsure use 0.1.
-func New(epsilon, delta float64) *CountMinSketch {
+func New(epsilon, delta float64) (*CountMinSketch, error) {
+	if epsilon < 0.0 || epsilon > 1.0 {
+		err := fmt.Errorf("epsilon must be between (0, 1), but %f was given", epsilon)
+		return nil, err
+	}
+	if delta < 0.0 || delta > 1.0 {
+		err := fmt.Errorf("delta must be between (0, 1), but %f was given", delta)
+		return nil, err
+	}
+
 	m := calculateM(epsilon)
 	k := calculateK(delta)
 	hashes, seeds := createHashFunctions(k)
@@ -57,7 +66,7 @@ func New(epsilon, delta float64) *CountMinSketch {
 		contents[i] = make([]uint32, m)
 	}
 
-	return &CountMinSketch{m, k, seeds, contents, hashes}
+	return &CountMinSketch{m, k, seeds, contents, hashes}, nil
 }
 
 // Insert a byte sequence into the CMS.
@@ -170,7 +179,7 @@ func DecodeFromFile(filename string) *CountMinSketch {
 }
 
 func main() {
-	cms := New(0.1, 0.1)
+	cms, _ := New(0.1, 0.1)
 	fmt.Println(cms.K)
 	fmt.Println(cms.M)
 	cms.Insert([]byte{1, 2})

--- a/ds/hll/hll.go
+++ b/ds/hll/hll.go
@@ -26,16 +26,16 @@ type HLL struct {
 
 // Returns a pointer to a new HLL object.
 // precision: [4, 16]
-func New(precision int) *HLL {
+func New(precision int) (*HLL, error) {
 	if precision < HLL_MIN_PRECISION || precision > HLL_MAX_PRECISION {
-		errMsg := fmt.Sprint("precision must be between ", HLL_MIN_PRECISION, " and ", HLL_MAX_PRECISION, ", but ", precision, " was given.")
-		panic(errMsg)
+		err := fmt.Errorf("precision must be between %d and %d, but %d was given", HLL_MIN_PRECISION, HLL_MAX_PRECISION, precision)
+		return nil, err
 	}
 
 	m := uint64(math.Pow(2, float64(precision)))
 	reg := make([]uint8, m)
 
-	return &HLL{m, uint8(precision), reg}
+	return &HLL{m, uint8(precision), reg}, nil
 }
 
 func (hll *HLL) Add(data []byte) {

--- a/ds/merkletree/merkletree.go
+++ b/ds/merkletree/merkletree.go
@@ -3,6 +3,7 @@ package merkletree
 import (
 	"bufio"
 	"crypto/sha1"
+	"errors"
 	"os"
 )
 
@@ -12,10 +13,13 @@ type MerkleTree struct {
 }
 
 // New constructs a new merkle tree from a given slice of nodes.
-func New(level []MerkleNode) MerkleTree {
+func New(level []MerkleNode) (*MerkleTree, error) {
+	if len(level) == 0 {
+		return nil, errors.New("cannot build Merkle Tree from 0 nodes")
+	}
 	tree := MerkleTree{}
 	tree.Root = &tree.build(level)[0]
-	return tree
+	return &tree, nil
 }
 
 // build is a recursive function for building the next level of nodes.
@@ -23,10 +27,6 @@ func New(level []MerkleNode) MerkleTree {
 // Empty nodes do not alter the merged hash value of the parent node.
 // Returns the newly created level. The very last call will always return just one node - the root.
 func (tree *MerkleTree) build(level []MerkleNode) []MerkleNode {
-	if len(level) == 0 {
-		panic("Cannot build Merkle Tree from 0 nodes.")
-	}
-
 	if len(level)%2 != 0 {
 		level = append(level, MerkleNode{Data: []byte{}})
 	}

--- a/ds/tokenbucket/tokenbucket.go
+++ b/ds/tokenbucket/tokenbucket.go
@@ -19,14 +19,10 @@ type TokenBucket struct {
 //  resetInterval    Length of time (in seconds) for which the current timestamp is valid
 //  returns          Pointer to a TokenBucket object
 // Throws if the maxTokens and/or resetInterval parameters are not positive numbers.
-func New(maxTokens int, resetInterval int64) *TokenBucket {
-	if maxTokens <= 0 {
-		errMsg := fmt.Sprint("maxTokens must be a positive number, but ", maxTokens, " was given.")
-		panic(errMsg)
-	}
-	if resetInterval <= 0 {
-		errMsg := fmt.Sprint("resetInterval must be a positive number, but ", resetInterval, " was given.")
-		panic(errMsg)
+func New(maxTokens int, resetInterval int64) (*TokenBucket, error) {
+	err := ValidateParams(maxTokens, int(resetInterval))
+	if err != nil {
+		return nil, err
 	}
 
 	return &TokenBucket{
@@ -34,7 +30,20 @@ func New(maxTokens int, resetInterval int64) *TokenBucket {
 		Tokens:        maxTokens,
 		Timestamp:     time.Now().Unix(),
 		ResetInterval: resetInterval,
+	}, nil
+}
+
+func ValidateParams(maxTokens, resetInterval int) error {
+	if maxTokens <= 0 {
+		err := fmt.Errorf("maxTokens must be a positive number, but %d was given", maxTokens)
+		return err
 	}
+	if resetInterval <= 0 {
+		err := fmt.Errorf("resetInterval must be a positive number, but %d was given", resetInterval)
+		return err
+	}
+
+	return nil
 }
 
 // HasEnoughTokens checks if the TokenBucket has enough tokens for the user's request.

--- a/engine/coreeng/coreeng.go
+++ b/engine/coreeng/coreeng.go
@@ -18,23 +18,24 @@ import (
 )
 
 type CoreEngine struct {
-	conf  coreconf.CoreConfig
+	conf  *coreconf.CoreConfig
 	cache *lru.LRU
 	mt    *memtable.Memtable
 	wal   *wal.WAL
 }
 
-func New(conf coreconf.CoreConfig) *CoreEngine {
-	if len(conf.InternalStart) == 0 {
-		return nil
-	}
+func New(conf *coreconf.CoreConfig) (*CoreEngine, error) {
+	// Since New uses CoreConfig (which should always have valid values), we don't need to check for errors here
+	lru, _ := lru.New(conf.CacheCapacity)
+	memtable, _ := memtable.New(conf)
+	wal, _ := wal.New(conf.WalPath, conf.DBName, conf.WalMaxRecsInSeg, conf.WalLwmIdx, conf.WalBufferCapacity)
+
 	return &CoreEngine{
 		conf,
-		lru.New(conf.CacheCapacity),
-		memtable.New(conf),
-		wal.New(conf.WalPath, conf.DBName, conf.WalMaxRecsInSeg,
-			conf.WalLwmIdx, conf.WalBufferCapacity),
-	}
+		lru,
+		memtable,
+		wal,
+	}, nil
 }
 
 // IsLegal returns true if legal key, otherwise false
@@ -164,7 +165,8 @@ func (cen CoreEngine) getTokenBucket(user []byte) tokenbucket.TokenBucket {
 	tbKey = append(tbKey, user...)
 	tbRec, found := cen.get(tbKey)
 	if !found {
-		return *tokenbucket.New(cen.conf.TokenBucketTokens, cen.conf.TokenBucketInterval)
+		tb, _ := tokenbucket.New(cen.conf.TokenBucketTokens, cen.conf.TokenBucketInterval)
+		return *tb
 	}
 	return tokenbucket.FromBytes(tbRec.Value)
 }
@@ -241,8 +243,8 @@ func (cen CoreEngine) FlushWALBuffer() {
 }
 
 func main() {
-	engine := *New(coreconf.LoadConfig("conf.yaml"))
-	test(engine)
+	engine, _ := New(coreconf.LoadConfig("conf.yaml"))
+	test(*engine)
 }
 
 func test(engine CoreEngine) {

--- a/engine/wrappereng/wrappereng.go
+++ b/engine/wrappereng/wrappereng.go
@@ -20,8 +20,10 @@ type WrapperEngine struct {
 	core coreeng.CoreEngine
 }
 
-func New(conf coreconf.CoreConfig) WrapperEngine {
-	return WrapperEngine{*coreeng.New(conf)}
+func New(conf *coreconf.CoreConfig) WrapperEngine {
+	coreeng, _ := coreeng.New(conf)
+
+	return WrapperEngine{*coreeng}
 }
 
 func (wen WrapperEngine) PutTyped(user, key string, val []byte, typeInfo byte) bool {
@@ -78,7 +80,7 @@ func test(engine WrapperEngine) {
 
 	// cms testing
 	fmt.Println("===CMS===")
-	cms := *cmsketch.New(0.1, 0.1)
+	cms, _ := cmsketch.New(0.1, 0.1)
 	fmt.Println(cms.K)
 	fmt.Println(cms.M)
 	cms.Insert([]byte{1, 2})
@@ -89,7 +91,7 @@ func test(engine WrapperEngine) {
 	fmt.Println(cms.Query([]byte{3, 4}))
 	fmt.Println(cms.Query([]byte{2, 5}))
 	fmt.Println("AFTER ENGINEERING")
-	engine.PutCMS(user, "cs", cms)
+	engine.PutCMS(user, "cs", *cms)
 	rec, found := engine.Get(user, "cs")
 	if !found || rec.TypeInfo != TypeCountMinSketch {
 		panic(rec)
@@ -107,7 +109,7 @@ func test(engine WrapperEngine) {
 
 	// hll testing
 	fmt.Println("\n===HLL===")
-	hll1 := *hll.New(4)
+	hll1, _ := hll.New(4)
 	hll1.Add([]byte{1, 2})
 	hll1.Add([]byte{1, 2})
 	hll1.Add([]byte{1, 2})
@@ -115,7 +117,7 @@ func test(engine WrapperEngine) {
 	hll1.Add([]byte{5, 4, 120})
 	fmt.Println(hll1.Estimate())
 	fmt.Println("AFTER ENGINEERING")
-	engine.PutHLL(user, "hl", hll1)
+	engine.PutHLL(user, "hl", *hll1)
 	rec, found = engine.Get(user, "hl")
 	if !found || rec.TypeInfo != TypeHyperLogLog {
 		panic(rec)

--- a/engine/wrappertest/clitest.go
+++ b/engine/wrappertest/clitest.go
@@ -192,12 +192,13 @@ func (cli *CLITest) hllc() bool {
 		cli.state = _BAD_ARGV
 		return false
 	}
-	if k > hyperloglog.HLL_MAX_PRECISION || k < hyperloglog.HLL_MIN_PRECISION {
+
+	hll, err := hyperloglog.New(k)
+	if err != nil {
 		cli.state = _BAD_ARGV
 		return false
 	}
 
-	hll := hyperloglog.New(k)
 	cli.eng.PutHLL(cli.user, key, *hll)
 
 	return true
@@ -250,12 +251,13 @@ func (cli *CLITest) cmsc() bool {
 		cli.state = _BAD_ARGV
 		return false
 	}
-	if e > 1.0 || e < 0.0 || d > 1.0 || d < 0.0 {
+
+	cms, err := cmsketch.New(e, d)
+	if err != nil {
 		cli.state = _BAD_ARGV
 		return false
 	}
 
-	cms := cmsketch.New(e, d)
 	cli.eng.PutCMS(cli.user, key, *cms)
 
 	return true


### PR DESCRIPTION
- made New of a bunch of structs return error, as well as a pointer to an object
- LSM: made capital Compact check the validity of its arguments, after which recursive calls go through compact (not sure about this change)
- coreconf now gets passed by pointer instead of value in a couple of places
- added ValidateParams function for a couple of structs, so that we can use the result of the validity in coreconf by calling ValidateParams
- coreconf validates its members, calling log.Fatal if any of them are invalid
    - this is much easier to do, and the alternative (setting invalid members to their default values) doesn't have a good cost-
      benefit ratio

Closes #51

Note: I have only tested using the CLI. Can someone validate this doesn't affect any of our other tests?