### PR TITLE
support for whitespace between number and units

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -4,7 +4,7 @@ db_name: nakevaleng
 skiplist_level: 3
 skiplist_level_max: 5
 memtable_capacity: 10
-memtable_threshold: 2KB
+memtable_threshold: 2.KB
 memtable_flush_strategy: 3
 cache_capacity: 5
 summary_page_size: 3

--- a/conf.yaml
+++ b/conf.yaml
@@ -4,7 +4,7 @@ db_name: nakevaleng
 skiplist_level: 3
 skiplist_level_max: 5
 memtable_capacity: 10
-memtable_threshold: 2.KB
+memtable_threshold: 2KB
 memtable_flush_strategy: 3
 cache_capacity: 5
 summary_page_size: 3

--- a/conf.yaml
+++ b/conf.yaml
@@ -4,7 +4,7 @@ db_name: nakevaleng
 skiplist_level: 3
 skiplist_level_max: 5
 memtable_capacity: 10
-memtable_threshold: 2 KB
+memtable_threshold: 2KB
 memtable_flush_strategy: 3
 cache_capacity: 5
 summary_page_size: 3

--- a/core/memtable/memtable.go
+++ b/core/memtable/memtable.go
@@ -22,10 +22,15 @@ func New(conf *coreconf.CoreConfig) (*Memtable, error) {
 	// if conf is valid, this should never fail
 	sl, _ := skiplist.New(conf.SkiplistLevel, conf.SkiplistLevelMax)
 
+	threshold, err := conf.MemtableThresholdBytes()
+	if err != nil {
+		fmt.Println("Invalid configuration for threshold:", err, "\nreverting to default:", threshold)
+	}
+
 	return &Memtable{
 		conf:      conf,
 		memusage:  uint64(0),
-		threshold: conf.MemtableThresholdBytes(),
+		threshold: threshold,
 		sl:        sl,
 	}, nil
 }

--- a/engine/coreconf/coreconf.go
+++ b/engine/coreconf/coreconf.go
@@ -231,7 +231,7 @@ func (conf *CoreConfig) MemtableThresholdBytes() (uint64, error) {
 	if !ok {
 		conf.MemtableThreshold = GetDefault().MemtableThreshold
 		fallback, _ := conf.MemtableThresholdBytes()
-		return fallback, fmt.Errorf("Bad unit:", unit)
+		return fallback, fmt.Errorf("Bad unit: %s", unit)
 	}
 
 	// Convert to bytes

--- a/engine/coreconf/coreconf.go
+++ b/engine/coreconf/coreconf.go
@@ -12,7 +12,6 @@ import (
 	"nakevaleng/ds/tokenbucket"
 	"os"
 	"strconv"
-	"strings"
 
 	"gopkg.in/yaml.v2"
 )
@@ -186,12 +185,30 @@ func (conf CoreConfig) Dump(filePath string) {
 }
 
 func (conf *CoreConfig) MemtableThresholdBytes() uint64 {
-	// Parse
-	parts := strings.Split(conf.MemtableThreshold, " ")
-	if len(parts) != 2 {
-		conf.MemtableThreshold = GetDefault().MemtableThreshold
-		return conf.MemtableThresholdBytes()
+	isAlphaNum := func(s rune) bool {
+		return s >= '0' && s <= '9'
 	}
+
+	// Parse
+
+	strBucket := 0
+	parts := [2]string{
+		"", // Number
+		"", // Unit of memory
+	}
+
+	for _, ch := range conf.MemtableThreshold {
+		if ch == ' ' {
+			continue
+		}
+		if strBucket == 0 && !isAlphaNum(ch) {
+			strBucket = 1
+		}
+
+		parts[strBucket] += string(ch)
+	}
+
+	// Parse
 
 	// How many units
 	howMany, err := strconv.Atoi(parts[0])
@@ -219,5 +236,6 @@ func (conf *CoreConfig) MemtableThresholdBytes() uint64 {
 	for i := 0; i < exp; i++ {
 		m *= 1024
 	}
+
 	return uint64(howMany) * m
 }

--- a/engine/coreconf/coreconf.go
+++ b/engine/coreconf/coreconf.go
@@ -184,7 +184,7 @@ func (conf CoreConfig) Dump(filePath string) {
 	}
 }
 
-func (conf *CoreConfig) MemtableThresholdBytes() uint64 {
+func (conf *CoreConfig) MemtableThresholdBytes() (uint64, error) {
 	isAlphaNum := func(s rune) bool {
 		return s >= '0' && s <= '9'
 	}
@@ -213,7 +213,9 @@ func (conf *CoreConfig) MemtableThresholdBytes() uint64 {
 	// How many units
 	howMany, err := strconv.Atoi(parts[0])
 	if err != nil {
-		panic(err)
+		conf.MemtableThreshold = GetDefault().MemtableThreshold
+		fallback, _ := conf.MemtableThresholdBytes()
+		return fallback, err
 	}
 	unit := parts[1]
 
@@ -228,7 +230,8 @@ func (conf *CoreConfig) MemtableThresholdBytes() uint64 {
 	exp, ok := exponent[unit]
 	if !ok {
 		conf.MemtableThreshold = GetDefault().MemtableThreshold
-		return conf.MemtableThresholdBytes()
+		fallback, _ := conf.MemtableThresholdBytes()
+		return fallback, fmt.Errorf("Bad unit:", unit)
 	}
 
 	// Convert to bytes
@@ -237,5 +240,5 @@ func (conf *CoreConfig) MemtableThresholdBytes() uint64 {
 		m *= 1024
 	}
 
-	return uint64(howMany) * m
+	return uint64(howMany) * m, nil
 }


### PR DESCRIPTION
"2KB" will work the same was as "2 KB" etc.